### PR TITLE
Update broken depends

### DIFF
--- a/Formula/cairo-xlib.rb
+++ b/Formula/cairo-xlib.rb
@@ -17,7 +17,7 @@ class CairoXlib < Formula
   depends_on "glib"
   depends_on "libpng"
   depends_on "pixman"
-  depends_on :x11
+  depends_on "xquartz"
 
   keg_only "A cairo installation may already be present."
 

--- a/Formula/imlib2-xlib.rb
+++ b/Formula/imlib2-xlib.rb
@@ -10,7 +10,7 @@ class Imlib2Xlib < Formula
   depends_on "jpeg"
   depends_on "libpng"
   depends_on "libtiff"
-  depends_on :x11
+  depends_on "xquartz"
 
   keg_only "An imlib2 installation may already be present."
 


### PR DESCRIPTION
I replaced all `depends_on :x11` with `depends_on "xquartz"` so it could be tapped. Previously, tapping was impossible due to syntax errors.